### PR TITLE
Clone repository to temporary directory

### DIFF
--- a/test.py
+++ b/test.py
@@ -2,28 +2,14 @@
 
 import unittest
 import os
-from install import parse_args, org_repo_from_url
-
-
-class TestParseUrl(unittest.TestCase):
-    def test_http_dot_git(self):
-        self.assertEqual(org_repo_from_url("https://github.com/org/repo.git"), ("org", "repo"))
-    
-    def test_http(self):
-        self.assertEqual(org_repo_from_url("https://github.com/org/repo"), ("org", "repo"))
-
-    def test_ssh_dot_git(self):
-        self.assertEqual(org_repo_from_url("git@github.com:org/repo.git"), ("org", "repo"))
-    
-    def test_ssh(self):
-        self.assertEqual(org_repo_from_url("git@github.com:org/repo"), ("org", "repo"))
+from install import parse_args
 
 
 class TestArgs(unittest.TestCase):
     def test_full(self):
-        cli = ['https://example.com/org/repo', '--ref=tagname', 'extra', 'args', '--script=Makefile']
+        cli = ['https://example.com/org/repo', '--directory=D', '--ref=tagname', 'extra', 'args', '--script=Makefile']
         a, remaining, _ = parse_args(cli)
-        self.assertEqual(os.path.expanduser('~/workspace/org/repo'), a.directory)
+        self.assertEqual('D', a.directory)
         self.assertEqual(a.ref, 'tagname')
         self.assertEqual(a.script, 'Makefile')
         self.assertEqual(remaining, ['extra', 'args'])


### PR DESCRIPTION
When cloning a repository, place it in a temporary directory instead of the home directory. If a temporary directory was created, delete it afterward.

If an explicit/existing directory was cited, do not delete it.

Bonus: List remote branches available for checkout.

Fixes: issue #1